### PR TITLE
Use argv-split to split command into arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var util = require('util'),
-    spawn = require('child_process').spawn;
+    spawn = require('child_process').spawn,
+    split = require('argv-split');;
 
 module.exports = function(command, options, callback) {
     // passthru(command, callback)
@@ -15,7 +16,7 @@ module.exports = function(command, options, callback) {
 
     // passthru("ls -la /tmp") => passthru(["ls", "-la", "/tmp"])
     if (typeof command == 'string') {
-        command = command.split(' ');
+        command = split(command);
     }
 
     if (!options.cwd) {

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   },
   "scripts": {
     "test": "test/test.sh"
+  },
+  "dependencies": {
+    "argv-split": "^1.0.1"
   }
 }

--- a/test/quotes.js
+++ b/test/quotes.js
@@ -1,0 +1,10 @@
+var abort = setTimeout(function() {
+    console.error('Timeout reached, aborting.');
+    process.exit(1);
+}, 1000);
+
+var passthru = require('..');
+passthru('bash -c "echo this has a space in it"', function(err) {
+    if (err) throw err;
+    clearTimeout(abort);
+});

--- a/test/test.sh
+++ b/test/test.sh
@@ -21,5 +21,19 @@ if [ $RETVAL -ne 0 ]; then
     exit 1
 fi
 
+EXPECTED3="this has a space in it"
+ACTUAL3=`node test/quotes.js`
+RETVAL=$?
+
+if [ $RETVAL -ne 0 ]; then
+    echo -e "FAILED 3: Expecting exit code 0, but got $RETVAL."
+    exit 1
+fi
+
+if [ "$EXPECTED3" != "$ACTUAL3" ]; then
+    echo -e "FAILED 3: Expecting string '$EXPECTED3', but got '$ACTUAL3'."
+    exit 1
+fi
+
 echo 'PASSED'
 exit 0


### PR DESCRIPTION
Splitting by space does not respect quoted arguments, so I added a dependency on `argv-split` which splits in a better way.

Includes a test.
